### PR TITLE
feat[#127] update review

### DIFF
--- a/src/main/java/com/simsasookbak/accommodation/controller/AccommodationController.java
+++ b/src/main/java/com/simsasookbak/accommodation/controller/AccommodationController.java
@@ -105,7 +105,6 @@ public class AccommodationController {
             @RequestParam(value = "id", required = false) Long id,
             Model model
     ) {
-        // TODO 테스트 : 댓글을 단 사용자가 아닌경우 수정 불가
         if (id != null) {
             ReviewDto reviewWithImages = reviewService.findReviewById(id, member.getId());
             model.addAttribute("reviewWithImages", reviewWithImages);

--- a/src/main/java/com/simsasookbak/accommodation/controller/AccommodationController.java
+++ b/src/main/java/com/simsasookbak/accommodation/controller/AccommodationController.java
@@ -4,9 +4,9 @@ import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.simsasookbak.accommodation.domain.AccommodationImage;
 import com.simsasookbak.accommodation.dto.AccommodationDto;
-import com.simsasookbak.accommodation.dto.request.AccommodationRequest;
-import com.simsasookbak.accommodation.dto.request.AccommodationAndRoomsAddRequestDto;
 import com.simsasookbak.accommodation.dto.AccommodationUpdateDto;
+import com.simsasookbak.accommodation.dto.request.AccommodationAndRoomsAddRequestDto;
+import com.simsasookbak.accommodation.dto.request.AccommodationRequest;
 import com.simsasookbak.accommodation.dto.response.AccommodationAddResponseDto;
 import com.simsasookbak.accommodation.dto.response.AccommodationResponse;
 import com.simsasookbak.accommodation.service.AccommodationImageService;
@@ -18,21 +18,17 @@ import com.simsasookbak.review.dto.ReviewDto;
 import com.simsasookbak.review.service.ReviewService;
 import com.simsasookbak.room.dto.RoomDto;
 import com.simsasookbak.room.service.RoomService;
-
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -102,15 +98,25 @@ public class AccommodationController {
 
 
     //리뷰 등록 페이지 이동
-    @GetMapping("/{acom_id}/comment")
-    public String review(@PathVariable Long acom_id, Model model) {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        Member member = (Member) authentication.getPrincipal();
-        model.addAttribute("accommodation", acom_id);
+    @GetMapping("/{accommodationId}/comment")
+    public String review(
+            @AuthenticationPrincipal Member member,
+            @PathVariable Long accommodationId,
+            @RequestParam(value = "id", required = false) Long id,
+            Model model
+    ) {
+        // TODO 테스트 : 댓글을 단 사용자가 아닌경우 수정 불가
+        if (id != null) {
+            ReviewDto reviewWithImages = reviewService.findReviewById(id, member.getId());
+            model.addAttribute("reviewWithImages", reviewWithImages);
+        }
+
+        model.addAttribute("accommodation", accommodationId);
         model.addAttribute("member", member.getId());
-        model.addAttribute("RoomNames", reservationService.getReservationRoomName(acom_id, member.getId()));
+        model.addAttribute("RoomNames", reservationService.getReservationRoomName(accommodationId, member.getId()));
         return "review-register";
     }
+
 
     @MethodInvocationLimit
     @PostMapping("/registerPage/register")

--- a/src/main/java/com/simsasookbak/review/domain/Review.java
+++ b/src/main/java/com/simsasookbak/review/domain/Review.java
@@ -56,10 +56,14 @@ public class Review extends BaseEntity {
     @ColumnDefault("'일반실'")
     private String roomTitle;
 
-    /*`summary_id`	bigint	NOT NULL*/
-
-
     public void changeToDelete(){
         this.isDeleted=true;
+    }
+    public void modify(
+            String content,
+            Integer score
+    ) {
+        this.content = content;
+        this.score = score;
     }
 }

--- a/src/main/java/com/simsasookbak/review/dto/ReviewDto.java
+++ b/src/main/java/com/simsasookbak/review/dto/ReviewDto.java
@@ -1,10 +1,9 @@
 package com.simsasookbak.review.dto;
 
 import com.simsasookbak.review.domain.Review;
+import com.simsasookbak.review.domain.ReviewImage;
 import java.time.LocalDateTime;
 import java.util.List;
-
-import com.simsasookbak.review.domain.ReviewImage;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -18,6 +17,7 @@ public class ReviewDto {
 
     private Long reviewId;
     private String memberName;
+    private String memberId;
     private Long accommodationId;
     private String content;
     private Integer score;
@@ -33,6 +33,7 @@ public class ReviewDto {
         return ReviewDto.builder()
                 .reviewId(review.getId())
                 .accommodationId(review.getAccommodation().getId())
+                .memberId(review.getMember().getEmail())
                 .memberName(
                         review.getMember().getName())
                 .content(review.getContent())

--- a/src/main/java/com/simsasookbak/review/repository/ReviewImageRepository.java
+++ b/src/main/java/com/simsasookbak/review/repository/ReviewImageRepository.java
@@ -2,17 +2,12 @@ package com.simsasookbak.review.repository;
 
 import com.simsasookbak.review.domain.Review;
 import com.simsasookbak.review.domain.ReviewImage;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
 
 @Repository
 public interface ReviewImageRepository extends JpaRepository<ReviewImage,Long> {
 
     List<ReviewImage> findAllByReview(Review review);
-
-
-//    @Query(value = "INSERT INTO review_image(review_id,url) VALUES (:reviewId , :url)")
-//    void saveToDb(Long reviewId,String url);
 }

--- a/src/main/java/com/simsasookbak/review/repository/ReviewRepository.java
+++ b/src/main/java/com/simsasookbak/review/repository/ReviewRepository.java
@@ -1,15 +1,11 @@
 package com.simsasookbak.review.repository;
 
 import com.simsasookbak.review.domain.Review;
-import java.util.List;
 import com.simsasookbak.review.dto.ScoreAverageDto;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.stereotype.Repository;
-
-import java.util.List;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -32,8 +28,6 @@ public interface ReviewRepository extends JpaRepository<Review,Long> {
 
     List<Review> findAllByMember_Id(Long memberId);
 
-
-//    @Query("SELECT ScoreAverageDto(r.accommodation.id, AVG(r.score)) FROM Review r GROUP BY r.accommodation.id ORDER BY AVG(r.score) DESC, r.accommodation.id DESC")
-//    List<ScoreAverageDto> findAverageScoreByAccommodationId();
+    Review findByIdAndMemberIdAndIsDeletedFalse(Long reviewId, Long memberId);
 
 }

--- a/src/main/java/com/simsasookbak/review/service/ReviewService.java
+++ b/src/main/java/com/simsasookbak/review/service/ReviewService.java
@@ -23,6 +23,12 @@ public class ReviewService {
     private final ReviewRepository reviewRepository;
     private final ReviewImageRepository reviewImageRepository;
 
+    public ReviewDto findReviewById(Long reviewId, Long memberId) {
+        Review review = reviewRepository.findByIdAndMemberIdAndIsDeletedFalse(reviewId, memberId);
+        List<ReviewImage> reviewImages = reviewImageRepository.findAllByReview(review);
+        return ReviewDto.toDto(review, reviewImages);
+    }
+
     public String findExSummaryByAcomId(Long id) {
         return reviewRepository.findExSummaryByAcomId(id);
     }
@@ -69,4 +75,10 @@ public class ReviewService {
         return reviewImageRepository.findAllByReview(reviewId);
     }
 
+    @Transactional
+    public Review modify(Long id, String content, Integer score) {
+        Review review = reviewRepository.findById(id).orElseThrow(IllegalArgumentException::new);
+        review.modify(content, score);
+        return review;
+    }
 }

--- a/src/main/resources/templates/details.html
+++ b/src/main/resources/templates/details.html
@@ -183,8 +183,8 @@
                                             <div class="btn-area col-md-2">
                                                 <!--TODO 수정 버튼 -->
                                                 <button class="btn btn-primary" id="modify-btn"
-                                                        th:onclick="|location.href='${accommodation.getId()}/comment?id=${review.getReviewId()}'|"
-                                                        type="button">수정</button>
+                                                        th:if="${review.getMemberId() == #authentication.getName()}"
+                                                        th:onclick="|location.href='${accommodation.getId()}/comment?id=${review.getReviewId()}'|" type="button" >수정</button>
                                                 <button class="btn btn-primary" type="button">Button</button>
                                             </div>
                                         </div>

--- a/src/main/resources/templates/details.html
+++ b/src/main/resources/templates/details.html
@@ -181,7 +181,10 @@
                                                  th:text="'별점 : '+ ${review.getScore()}">
                                             </div>
                                             <div class="btn-area col-md-2">
-                                                <button class="btn btn-primary" type="button">Button</button>
+                                                <!--TODO 수정 버튼 -->
+                                                <button class="btn btn-primary" id="modify-btn"
+                                                        th:onclick="|location.href='${accommodation.getId()}/comment?id=${review.getReviewId()}'|"
+                                                        type="button">수정</button>
                                                 <button class="btn btn-primary" type="button">Button</button>
                                             </div>
                                         </div>
@@ -208,7 +211,7 @@
         </div>
         <div class="text-center">
             <a class="btn btn-primary rounded-pill py-3 px-5 mt-2" id="moreButton" style="margin-right: 20px">리뷰 더보기</a>
-            <a class="btn btn-primary rounded-pill py-3 px-5 mt-2" th:href="@{${accommodation.getId()}+'/comment'}">리뷰 등록</a>
+            <a class="btn btn-primary rounded-pill py-3 px-5 mt-2" th:href="@{${accommodation.getId()} +'/comment'}">리뷰 등록</a>
         </div>
     </div>
 </div>
@@ -218,7 +221,6 @@
 <input id="reviewList" th:value="${reviewList}" type="hidden"/>
 
 <footer th:replace="~{layout/footer::footerFragment}"></footer>
-
 </body>
 
 </html>

--- a/src/main/resources/templates/details.html
+++ b/src/main/resources/templates/details.html
@@ -181,11 +181,9 @@
                                                  th:text="'별점 : '+ ${review.getScore()}">
                                             </div>
                                             <div class="btn-area col-md-2">
-                                                <!--TODO 수정 버튼 -->
                                                 <button class="btn btn-primary" id="modify-btn"
                                                         th:if="${review.getMemberId() == #authentication.getName()}"
                                                         th:onclick="|location.href='${accommodation.getId()}/comment?id=${review.getReviewId()}'|" type="button" >수정</button>
-                                                <button class="btn btn-primary" type="button">Button</button>
                                             </div>
                                         </div>
                                     </div>

--- a/src/main/resources/templates/review-register.html
+++ b/src/main/resources/templates/review-register.html
@@ -1,34 +1,6 @@
 <!DOCTYPE html>
-<html lang="en">
-
-<head>
-    <meta charset="utf-8">
-    <title>Travela - Tourism Website Template</title>
-    <meta content="width=device-width, initial-scale=1.0" name="viewport">
-    <meta content="" name="keywords">
-    <meta content="" name="description">
-
-    <!-- Google Web Fonts -->
-    <link href="https://fonts.googleapis.com" rel="preconnect">
-    <link crossorigin href="https://fonts.gstatic.com" rel="preconnect">
-    <link href="https://fonts.googleapis.com/css2?family=Jost:wght@500;600&family=Roboto&display=swap" rel="stylesheet">
-
-    <!-- Icon Font Stylesheet -->
-    <link href="https://use.fontawesome.com/releases/v5.15.4/css/all.css" rel="stylesheet"/>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.4.1/font/bootstrap-icons.css" rel="stylesheet">
-
-    <!-- Libraries Stylesheet -->
-    <link href="/lib/owlcarousel/assets/owl.carousel.min.css" rel="stylesheet">
-    <link href="/lib/lightbox/css/lightbox.min.css" rel="stylesheet">
-
-
-    <!-- Customized Bootstrap Stylesheet -->
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-
-    <!-- Template Stylesheet -->
-    <link href="/css/style.css" rel="stylesheet">
-</head>
-
+<html lang="ko-KR" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{layout/head::headFragment}"></head>
 <body>
 
 <div th:replace="~{layout/top-bar :: top}"></div>
@@ -41,11 +13,10 @@
             <h5 class="section-title px-3">Review</h5>
             <h1 class="mb-0">솔직한 후기를 작성해 주세요!</h1>
         </div>
-        <form enctype="multipart/form-data" th:action="@{/review/register/{acom_id}(acom_id=${acom_id})}" th:method="post">
+        <form enctype="multipart/form-data" th:action="@{/review/register/{accommodationId}(accommodationId=${accommodationId})}" th:method="post">
             <div class="row g-3">
                 <div class="col-md-5">
                     <label class="form-label" for="reviewTitle">리뷰할 방 선택</label>
-<!--                    <input type="text" class="form-control" id="reviewTitle" placeholder="리뷰 제목을 입력하세요" required>-->
                     <select class="form-control" id="reviewTitle" name="roomTitle" required>
                         <option th:each="roomName:${RoomNames}" th:text="${roomName}" th:value="${roomName}"></option>
                     </select>
@@ -53,13 +24,14 @@
                         const titleInput = document.getElementById('reviewTitle');
                         let inputValue = titleInput.options[titleInput.selectedIndex];
                         if(inputValue === undefined){
-                            alert('숙소를 예약한 적이 없어 리뷰등록이 불가합니다.');
+                            let text = !reviewWithImages ? '수정' : '등록';
+                            alert(`숙소를 예약한 적이 없어 리뷰 ${text}이 불가합니다.`);
                         }
-
                     </script>
                 </div>
                 <input name="accommodation" th:value="${accommodation}" type="hidden">
                 <input name="member" th:value="${member}" type="hidden">
+                <input name="id" th:value="${reviewWithImages?.getReviewId()}" type="hidden">
                 <div class="col-md-5">
                     <label class="form-label" for="imageUpload">이미지 업로드</label>
                     <input accept="image/*" class="form-control" id="imageUpload" multiple name="file" onchange="addFile(this);" type="file">
@@ -76,11 +48,14 @@
                 </div>
                 <div class="mb-3">
                     <label class="form-label" for="reviewContent">리뷰 내용</label>
-                    <textarea class="form-control" id="reviewContent" name="content" placeholder="리뷰 내용을 입력하세요" required rows="10"></textarea>
+                    <textarea class="form-control" id="reviewContent" name="content" placeholder="리뷰 내용을 입력하세요" required rows="10" th:text="${reviewWithImages?.getContent()}"></textarea>
                 </div>
                 <div class="col-12">
                     <div class="text-center">
-                        <button class="btn btn-primary rounded-pill py-3 px-5 mt-2" href="" type="submit">리뷰 등록</button>
+                        <button class="btn btn-primary rounded-pill py-3 px-5 mt-2" th:switch="${reviewWithImages}" type="submit">
+                            <span th:case="null">등록</span>
+                            <span th:case="*">수정</span>
+                        </button>
                     </div>
                 </div>
             </div>
@@ -93,16 +68,6 @@
 
 <!-- Back to Top -->
 <a class="btn btn-primary btn-primary-outline-0 btn-md-square back-to-top" href="#"><i class="fa fa-arrow-up"></i></a>
-
-
-<!-- JavaScript Libraries -->
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.4/jquery.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0/dist/js/bootstrap.bundle.min.js"></script>
-<script src="/lib/easing/easing.min.js"></script>
-<script src="/lib/waypoints/waypoints.min.js"></script>
-<script src="/lib/owlcarousel/owl.carousel.min.js"></script>
-<script src="/lib/lightbox/js/lightbox.min.js"></script>
-
 
 <!-- Template Javascript -->
 <script src="/js/main.js"></script>


### PR DESCRIPTION
## #️⃣연관된 이슈

> #127 

## 📝작업 내용

> 기존 리뷰 등록 페이지를 이용해서 리뷰 수정 기능 추가 

## 참고사항 
- 제가 영석님께 숙소 상세 html 파일 전달을 위해 push를 하였는데, develop브랜치를 작업 브랜치로 잘못보고 push했습니다. 
- 롤백시키기 위해 revert 시켜두었습니다. 

- 또한, details.html을 기능 동작 확인 겸 수정해두었습니다.
  추후 해당 페이지 작업 시, 충돌 발생 할 수 있으니, 확인부탁드립니다.

## 💬 회고 
- 기존의 숙소 상세와 리뷰 등록 관련 로직들을 확인하니, 서비스, 레포지토리, DTO가 중구난방으로 되어있습니다. 
- 또한, DTO를 사용하지않고 엔티티를 직접적으로 사용되거나, @Data 어노테이션등의 지양되야할 부분이 너무 많습니다.
- 메서드 분리가 되지않고 스파게티 코드로 되어잇는 경우도 있고,  
- html의 경우도 css, js가 한 페이지내에 구성되어있고 
- 등록 메소드에 트랜잭션 어노테이션 등 이해가 되지않는 부분들이 너무 많아 해당 부분에서 의미없는 시간을 많이 소모하게되었습니다.
- 이런 경우에 제가 새로 로직을 아예 생성하지않는 한 기존 로직 재활용이 원활하게 이루어지지않아서 결국에는 신규로 추가되는 기능또한 동일한 스파게티 코드가 되어지는 점이 아쉽습니다. 
- 개발 기간이 많았다면, 리팩토링 및 신규 생성하였겠지만, 하루도 채 안되는 신규 기능 개발 시간에 해당 내용을 반영하기 어려워서 기존 코드를 사용하였습니다. 
- 디코 서버 텍스트 및 음성 채널에서 DTO 작성부터 공통 레이아웃 적용 등의 많은 논의를 하였지만, 반영되지 않고 코드가 개별적으로 따로 노는 점이 아쉬움이 많이 남습니다.  